### PR TITLE
Fixes issue with node-sass not found

### DIFF
--- a/Part2/package.json
+++ b/Part2/package.json
@@ -29,7 +29,7 @@
     "jshint-loader": "0.8.3",
     "ng-annotate-loader": "0.0.6",
     "node-sass": "3.2.0",
-    "sass-loader": "1.0.2",
+    "sass-loader": "^2.0.1",
     "style-loader": "0.12.3",
     "url-loader": "^0.5.6",
     "webpack": "1.10.1",


### PR DESCRIPTION
The sass-loader @ 1.0.2 was not properly loading peer dependency for node-sass, resulting in this error

```
ERROR in Cannot find module 'node-sass'
  @ ./app/index.scss 4:14-116 13:2-17:4 13:2-17:4 14:20-122
```

Updated to ^2.0.1 which resolves this.  Unsure if it causes any other issues. But the app is working for me after the update.
